### PR TITLE
docker, deps improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:latest
+FROM docker.io/node:20-alpine
 LABEL authors="kensand"
 
 WORKDIR "/rss-lemmy-bot"
 
 COPY . /rss-lemmy-bot
 
-RUN npm install && npm run build
+RUN npm install --production && npm run buildImage
 
+USER node
 CMD ["node", "./dist/cjs/main.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,19 +8,19 @@
       "name": "rss-lemmy-bot",
       "version": "0.1.0",
       "dependencies": {
+        "@types/node": "^20.3.1",
         "lemmy-js-client": "^0.18.0",
         "lru-cache": "^10.0.0",
         "node-html-markdown": "^1.3.0",
         "rss-parser": "^3.13.0",
-        "toad-scheduler": "^3.0.0"
+        "toad-scheduler": "^3.0.0",
+        "typescript": "^5.1.3"
       },
       "devDependencies": {
-        "@types/node": "^20.3.1",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
         "eslint": "^8.43.0",
-        "prettier": "^2.8.8",
-        "typescript": "^5.1.3"
+        "prettier": "^2.8.8"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -156,8 +156,7 @@
     "node_modules/@types/node": {
       "version": "20.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
-      "dev": true
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -1825,7 +1824,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
       "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1873,9 +1871,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2023,8 +2021,7 @@
     "@types/node": {
       "version": "20.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
-      "dev": true
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
     },
     "@types/semver": {
       "version": "7.5.0",
@@ -3197,8 +3194,7 @@
     "typescript": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
-      "dev": true
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -3233,9 +3229,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "eslint": "npx eslint --fix .",
     "_pre-build": "npm run prettier && npm run eslint",
     "build": "npm run _pre-build && tsc",
+    "buildImage": "tsc",
     "buildAndStart": "npm run build && npm run start",
     "start": "node ./dist/cjs/main.js"
   },
@@ -15,15 +16,15 @@
     "node-html-markdown": "^1.3.0",
     "rss-parser": "^3.13.0",
     "toad-scheduler": "^3.0.0",
-    "lru-cache": "^10.0.0"
+    "lru-cache": "^10.0.0",
+    "@types/node": "^20.3.1",
+    "typescript": "^5.1.3"
   },
   "devDependencies": {
-    "@types/node": "^20.3.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
     "eslint": "^8.43.0",
-    "prettier": "^2.8.8",
-    "typescript": "^5.1.3"
+    "prettier": "^2.8.8"
   },
   "files": [
     "./webpack/**",


### PR DESCRIPTION
- Best practice: Use fully-qualified repo name. Works better with
  podman.
- Slim down image size by using Alpine image.
- Slim down image size by removing prettier/eslint artifacts from build.
- Upgrade deps to address vuln warning
- Run container as `node`, not `root`, for improved security.

Container size was reduced by about 200 MB, or cut in half.
